### PR TITLE
fix(github): repair gathering for accounts that belong to organizations

### DIFF
--- a/Kexa/services/addOn/githubGathering.service.ts
+++ b/Kexa/services/addOn/githubGathering.service.ts
@@ -141,8 +141,9 @@ async function collectOrganizationRelaidInfo(allOrganizations: any): Promise<any
     }
 }
 
-async function collectRunnersInfo(org: string): Promise<any>{
-    let allRunners = [];
+async function collectRunnersInfo(org: string): Promise<any[]>{
+    if(!currentConfig?.ObjectNameNeed?.includes("runners")) return [];
+    let allRunners: any[] = [];
     logger.info("Collecting github runners");
     try{
         let octokit = await getOctokit();
@@ -160,9 +161,7 @@ async function collectRunnersInfo(org: string): Promise<any>{
     }catch(e){
         logger.debug(e);
     }
-    return {
-        allRunners
-    }
+    return allRunners;
 }
 
 async function collectTeamsRelaidInfo(org: string): Promise<any>{


### PR DESCRIPTION
## Summary
Found by the provider smoke-verification loop: the GitHub provider **silently gathered nothing for any account belonging to at least one organization** — in every run mode (source and binary alike).

`collectRunnersInfo()` returned `{ allRunners }` (an object) while its caller spreads the result into an array (`allRunners.push(...runners)`), throwing `Spread syntax requires ...iterable`. The error is caught at the `collectData` level, so the whole provider returned empty with only a log line.

**Fix:**
- return the array directly
- gate the runners collection on `ObjectNameNeed("runners")` like every other collector, so the per-org API call is skipped when no rule needs runners

## Verification
- Real token across 9 organizations: repositories + organizations gathered without errors, from source **and** from the compiled `--minify` binary
- Full provider smoke loop now passes 8/8 from the compiled binary: aws, github, helm, kubernetes, mongodb, mysql, oracle, postgresql
- 165/165 tests pass